### PR TITLE
Integrate Zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@swc/core": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,12 @@ specifiers:
   typescript: ^4.8.3
   vite: ^3.1.3
   vitest: ^0.23.4
+  zod: ^3.20.2
 
 dependencies:
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  zod: 3.20.2
 
 devDependencies:
   '@swc/core': 1.3.3
@@ -3493,3 +3495,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod/3.20.2:
+    resolution: {integrity: sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==}
+    dev: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,14 @@
+import { z } from 'zod';
+
+const User = z.object({
+  username: z.string(),
+});
+
+User.parse({ username: 'adamburmister' });
+
+// extract the inferred type
+type User = z.infer<typeof User>;
+
 const Link = (props: JSX.IntrinsicElements['a']) => (
   <a
     className="text-pink-500 underline hover:no-underline dark:text-pink-400"


### PR DESCRIPTION
I plan on using Zod schemas as the base for most TypeScript types within the boilerplate.
This will allow me to set up run-time validators etc for forms, but also use those same schemas as inferred types throughout.